### PR TITLE
Lucas rufo/gitignore mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ auth-service
 eureka-service
 config-service
 zuul-service
-configuration-repo
 
 /.metadata/
 
@@ -104,6 +103,15 @@ hibernate.cfg.xml
 
 # sonarlint modules
 .sonarlint
+
+# config files (bootstrap.yml will stay on repo, but no need to update it)
+bootstrap.yml
+application.yml
+
+# Target Directory
+target/
+
+.vscode/
 
 # hook-deps
 .hook-deps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# repos
+project-service
+auth-service
+eureka-service
+config-service
+zuul-service
+configuration-repo
+
+/.metadata/
+
 # Compiled class file
 *.class 
 
@@ -28,7 +38,6 @@ hs_err_pid*
 .metadata 
 bin/ 
 tmp/ 
-target/
 *.tmp 
 *.bak 
 *.swp 
@@ -96,9 +105,5 @@ hibernate.cfg.xml
 # sonarlint modules
 .sonarlint
 
-# config files (bootstrap.yml will stay on repo, but no need to update it)
-bootstrap.yml
-application.yml
-
-# vscode
-.vscode
+# hook-deps
+.hook-deps/


### PR DESCRIPTION
Modified .gitignore to include `hook-deps` folder. Two commits were made because the first was the meta repo's .gitignore with the `hook-deps` folder added. The second reversed this change by copying the original .gitignore of this repo and adding the new lines.